### PR TITLE
update fetch_subscribers to accept params

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -173,12 +173,14 @@ class Client
     /**
      * Returns a list of subscribers
      *
+     * @param array $params     Set of arguments
+     *                          - optional
      * @return \Drip\ResponseInterface
      */
-    public function fetch_subscribers()
+    public function fetch_subscribers($params=null)
     {
 
-        return $this->make_request("$this->account_id/subscribers");
+        return $this->make_request("$this->account_id/subscribers", $params);
     }
 
     /**


### PR DESCRIPTION
This update would allow the use of optional params shown in [List all Subscribers API](https://developer.drip.com/#list-all-subscribers). 