### PR TITLE
Updated the link for finding the account id

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ setting:
 $client = new \Drip\Client("YOUR_ACCESS_TOKEN", "YOUR_ACCOUNT_ID");
 ```
 
-Your account ID can be found [here](https://www.getdrip.com/settings/site).
+Your account ID can be found [here](https://www.getdrip.com/settings).
 Most API actions require an account ID, with the exception of methods like
 the "list accounts" endpoint.
 


### PR DESCRIPTION
The existing link `https://www.getdrip.com/settings/site` throws a HTTP 406 error.