### PR TITLE
[ECI-420] Use Bearer authorization for requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+* [#31](https://github.com/DripEmail/drip-php/pull/31) - Use Bearer authorization
 * Your improvement here!
 
 ## 1.3.0

--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ For private integrations, you may use your personal API Token (found
 [here](https://www.getdrip.com/user/edit)) via the `api_key` setting:
 
 ```php
-$client = new \Drip\Client("YOUR_API_KEY", "YOUR_ACCOUNT_ID");
+$client = new \Drip\Client(array("account_id" => "YOUR_ACCOUNT_ID", "api_key" => "YOUR_API_KEY"));
 ```
 
 For public integrations, pass in the user's OAuth token via the `access_token`
 setting:
 
 ```php
-$client = new \Drip\Client("YOUR_ACCESS_TOKEN", "YOUR_ACCOUNT_ID");
+$client = new \Drip\Client(array("account_id" => "YOUR_ACCOUNT_ID", "access_token" => "YOUR_ACCESS_TOKEN"));
 ```
 
 Your account ID can be found [here](https://www.getdrip.com/settings).

--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ For private integrations, you may use your personal API Token (found
 [here](https://www.getdrip.com/user/edit)) via the `api_key` setting:
 
 ```php
-$client = new \Drip\Client(array("account_id" => "YOUR_ACCOUNT_ID", "api_key" => "YOUR_API_KEY"));
+$client = new \Drip\Client(["account_id" => "YOUR_ACCOUNT_ID", "api_key" => "YOUR_API_KEY"]);
 ```
 
 For public integrations, pass in the user's OAuth token via the `access_token`
 setting:
 
 ```php
-$client = new \Drip\Client(array("account_id" => "YOUR_ACCOUNT_ID", "access_token" => "YOUR_ACCESS_TOKEN"));
+$client = new \Drip\Client(["account_id" => "YOUR_ACCOUNT_ID", "access_token" => "YOUR_ACCESS_TOKEN"]);
 ```
 
 Your account ID can be found [here](https://www.getdrip.com/settings).

--- a/src/Client.php
+++ b/src/Client.php
@@ -54,7 +54,11 @@ class Client
     public function __construct(...$params)
     {
         if (gettype($params[0]) === 'string') {
-            $this->deprecated_constructor($params[0], $params[1], $params[2]);
+            if (isset($params[2])) {
+                $this->deprecated_constructor($params[0], $params[1], $params[2]);
+            } else {
+                $this->deprecated_constructor($params[0], $params[1]);
+            }
         } else {
             $account_id = trim($params[0]['account_id']);
             if (array_key_exists('access_token', $params[0])) {
@@ -97,11 +101,11 @@ class Client
         }
         $this->account_id = $account_id;
 
-        if (is_array($options) && array_key_exists('api_end_point', $options)) {
+        if (array_key_exists('api_end_point', $options)) {
             $this->api_end_point = $options['api_end_point'];
         }
         // NOTE: For testing. Could break at any time, please do not depend on this.
-        if (is_array($options) && array_key_exists('guzzle_stack_constructor', $options)) {
+        if (array_key_exists('guzzle_stack_constructor', $options)) {
             $this->guzzle_stack_constructor = $options['guzzle_stack_constructor'];
         }
         // TODO: allow setting timeouts

--- a/src/Client.php
+++ b/src/Client.php
@@ -393,6 +393,7 @@ class Client
                 'User-Agent' => $this->user_agent(),
                 'Accept' => 'application/json, text/javascript, */*; q=0.01',
                 'Content-Type' => 'application/vnd.api+json',
+                'Authorization' => 'Bearer ' . $this->api_token,
             ],
             'http_errors' => false,
         ];

--- a/src/Client.php
+++ b/src/Client.php
@@ -49,7 +49,6 @@ class Client
      *               * `account_id` e.g. "123456"
      *               * `api_end_point` (mostly for Drip internal testing)
      *               * `guzzle_stack_constructor` (for test suite, may break at any time, do not use)
-     * 
      * @throws Exception
      */
     public function __construct(...$params)
@@ -78,6 +77,16 @@ class Client
         }
     }
 
+    /**
+     * Accepts API key and stores it internally -- format to be deprecated.
+     * 
+     * @param string $api_token
+     * @param string $account_id
+     * @param array  $options
+     *               * `api_end_point` (for test suite)
+     *               * `guzzle_stack_constructor` (for test suite)
+     * @throws Exception
+     */
     protected function deprecated_constructor($api_key, $account_id, $options = []) 
     {
         $account_id = trim($account_id);
@@ -98,6 +107,10 @@ class Client
         // TODO: allow setting timeouts
     }
 
+    /**
+     * @param string $api_key
+     * @throws Exception
+     */
     protected function basic_auth_setup($api_key) 
     {
         $api_key = trim($api_key);
@@ -107,6 +120,10 @@ class Client
         $this->api_key = $api_key;
     }
 
+    /**
+     * @param string $access_token
+     * @throws Exception
+     */
     protected function bearer_auth_setup($access_token) 
     {
         $access_token = trim($access_token);

--- a/src/Client.php
+++ b/src/Client.php
@@ -60,24 +60,13 @@ class Client
                 $this->deprecated_constructor($params[0], $params[1]);
             }
         } else {
-            $account_id = trim($params[0]['account_id']);
             if (array_key_exists('access_token', $params[0])) {
                 $this->bearer_auth_setup($params[0]['access_token']);
             } else {
                 $this->basic_auth_setup($params[0]['api_key']);
             }
-
-            if (array_key_exists('api_end_point', $params[0])) {
-                $this->api_end_point = $params[0]['api_end_point'];
-            }
-            if (array_key_exists('guzzle_stack_constructor', $params[0])) {
-                $this->guzzle_stack_constructor = $params[0]['guzzle_stack_constructor'];
-            }
-
-            if (empty($account_id) || !preg_match('#^[\w-]+$#si', $account_id)) {
-                throw new InvalidAccountIdException("Missing or invalid Drip account ID.");
-            }
-            $this->account_id = $account_id;
+            $this->set_test_options($params[0]);
+            $this->set_account_id($params[0]['account_id']);
         }//end if
     }
 
@@ -93,22 +82,9 @@ class Client
      */
     protected function deprecated_constructor($api_key, $account_id, $options = [])
     {
-        $account_id = trim($account_id);
         $this->basic_auth_setup($api_key);
-
-        if (empty($account_id) || !preg_match('#^[\w-]+$#si', $account_id)) {
-            throw new InvalidAccountIdException("Missing or invalid Drip account ID.");
-        }
-        $this->account_id = $account_id;
-
-        if (array_key_exists('api_end_point', $options)) {
-            $this->api_end_point = $options['api_end_point'];
-        }
-        // NOTE: For testing. Could break at any time, please do not depend on this.
-        if (array_key_exists('guzzle_stack_constructor', $options)) {
-            $this->guzzle_stack_constructor = $options['guzzle_stack_constructor'];
-        }
-        // TODO: allow setting timeouts
+        $this->set_account_id($account_id);
+        $this->set_test_options($options);
     }
 
     /**
@@ -137,6 +113,36 @@ class Client
         $this->access_token = $access_token;
 
         $this->bearer_auth = true;
+    }
+
+    /**
+     * @param string $account_id
+     * @throws Exception
+     */
+    protected function set_account_id($account_id)
+    {
+        $account_id = trim($account_id);
+        if (empty($account_id) || !preg_match('#^[\w-]+$#si', $account_id)) {
+            throw new InvalidAccountIdException("Missing or invalid Drip account ID.");
+        }
+        $this->account_id = $account_id;
+    }
+
+    /**
+     * @param array  $options
+     *               * `api_end_point`
+     *               * `guzzle_stack_constructor`
+     */
+    protected function set_test_options($options)
+    {
+        if (array_key_exists('api_end_point', $options)) {
+            $this->api_end_point = $options['api_end_point'];
+        }
+        // NOTE: For testing. Could break at any time, please do not depend on this.
+        if (array_key_exists('guzzle_stack_constructor', $options)) {
+            $this->guzzle_stack_constructor = $options['guzzle_stack_constructor'];
+        }
+        // TODO: allow setting timeouts
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -21,8 +21,6 @@ class Client
     protected $api_key = '';
     /** @var string */
     protected $access_token = '';
-    /** @var boolean */
-    protected $bearer_auth = false;
     /** @var string */
     protected $account_id = '';
     /** @var string */
@@ -111,8 +109,6 @@ class Client
             throw new InvalidAccessTokenException("Missing or invalid Drip access token.");
         }
         $this->access_token = $access_token;
-
-        $this->bearer_auth = true;
     }
 
     /**
@@ -461,7 +457,6 @@ class Client
         ]);
 
         $req_params = [
-            'auth' => [$this->api_key, ''],
             'timeout' => $this->timeout,
             'connect_timeout' => $this->connect_timeout,
             'headers' => [
@@ -472,9 +467,10 @@ class Client
             'http_errors' => false,
         ];
 
-        if ($this->bearer_auth) {
+        if (!empty($this->api_key)) {
+            $req_params['auth'] = [$this->api_key, ''];
+        } else if (!empty($this->access_token)) {
             $req_params['headers']['Authorization'] = 'Bearer ' . $this->access_token;
-            unset($req_params['auth']);
         }
 
         switch ($req_method) {

--- a/src/Client.php
+++ b/src/Client.php
@@ -78,12 +78,12 @@ class Client
                 throw new InvalidAccountIdException("Missing or invalid Drip account ID.");
             }
             $this->account_id = $account_id;
-        }
+        }//end if
     }
 
     /**
      * Accepts API key and stores it internally -- format to be deprecated.
-     * 
+     *
      * @param string $api_token
      * @param string $account_id
      * @param array  $options
@@ -91,7 +91,7 @@ class Client
      *               * `guzzle_stack_constructor` (for test suite)
      * @throws Exception
      */
-    protected function deprecated_constructor($api_key, $account_id, $options = []) 
+    protected function deprecated_constructor($api_key, $account_id, $options = [])
     {
         $account_id = trim($account_id);
         $this->basic_auth_setup($api_key);
@@ -115,7 +115,7 @@ class Client
      * @param string $api_key
      * @throws Exception
      */
-    protected function basic_auth_setup($api_key) 
+    protected function basic_auth_setup($api_key)
     {
         $api_key = trim($api_key);
         if (empty($api_key) || !preg_match('#^[\w-]+$#si', $api_key)) {
@@ -128,7 +128,7 @@ class Client
      * @param string $access_token
      * @throws Exception
      */
-    protected function bearer_auth_setup($access_token) 
+    protected function bearer_auth_setup($access_token)
     {
         $access_token = trim($access_token);
         if (empty($access_token) || !preg_match('#^[\w-]+$#si', $access_token)) {

--- a/src/Client.php
+++ b/src/Client.php
@@ -60,8 +60,10 @@ class Client
         } else {
             if (array_key_exists('access_token', $params[0])) {
                 $this->bearer_auth_setup($params[0]['access_token']);
-            } else {
+            } else if (array_key_exists('api_key', $params[0])) {
                 $this->basic_auth_setup($params[0]['api_key']);
+            } else {
+                throw new InvalidArgumentException("Missing Drip API key or access token.");
             }
             $this->set_test_options($params[0]);
             $this->set_account_id($params[0]['account_id']);

--- a/src/Exception/InvalidAccessTokenException.php
+++ b/src/Exception/InvalidAccessTokenException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Drip\Exception;
+
+class InvalidAccessTokenException extends DripException
+{
+}

--- a/src/Exception/InvalidApiKeyException.php
+++ b/src/Exception/InvalidApiKeyException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Drip\Exception;
+
+class InvalidApiKeyException extends DripException
+{
+}

--- a/src/Exception/InvalidApiKeyException.php
+++ b/src/Exception/InvalidApiKeyException.php
@@ -2,6 +2,6 @@
 
 namespace Drip\Exception;
 
-class InvalidApiKeyException extends DripException
+class InvalidApiKeyException extends InvalidApiTokenException
 {
 }

--- a/src/Exception/InvalidApiTokenException.php
+++ b/src/Exception/InvalidApiTokenException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Drip\Exception;
+
+class InvalidApiTokenException extends DripException
+{
+}

--- a/src/Exception/InvalidApiTokenException.php
+++ b/src/Exception/InvalidApiTokenException.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Drip\Exception;
-
-class InvalidApiTokenException extends DripException
-{
-}

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -19,13 +19,13 @@ final class ClientTest extends TestCase
 
     public function testInitializedWithAccessToken()
     {
-        $client = new \Drip\Client(array("account_id" => "1234", "access_token" => "abc123"));
+        $client = new \Drip\Client(["account_id" => "1234", "access_token" => "abc123"]);
         $this->assertInstanceOf(\Drip\Client::class, $client);
     }
 
     public function testInitializedWithApiKey()
     {
-        $client = new \Drip\Client(array("account_id" => "1234", "api_key" => "abc123"));
+        $client = new \Drip\Client(["account_id" => "1234", "api_key" => "abc123"]);
         $this->assertInstanceOf(\Drip\Client::class, $client);
     }
 
@@ -38,13 +38,13 @@ final class ClientTest extends TestCase
     public function testInvalidApiKey()
     {
         $this->expectException(\Drip\Exception\InvalidApiKeyException::class);
-        new \Drip\Client(array("account_id" => "1234", "api_key" => ""));
+        new \Drip\Client(["account_id" => "1234", "api_key" => ""]);
     }
 
     public function testInvalidAccessToken()
     {
         $this->expectException(\Drip\Exception\InvalidAccessTokenException::class);
-        new \Drip\Client(array("account_id" => "1234", "access_token" => ""));
+        new \Drip\Client(["account_id" => "1234", "access_token" => ""]);
     }
 
     public function testDeprecatedInvalidAccountId()
@@ -56,7 +56,7 @@ final class ClientTest extends TestCase
     public function testInvalidAccountId()
     {
         $this->expectException(\Drip\Exception\InvalidAccountIdException::class);
-        new \Drip\Client(array("account_id" => "", "api_key" => "abc123"));
+        new \Drip\Client(["account_id" => "", "api_key" => "abc123"]);
     }
 
     public function testErrorResponseReturned()

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -47,6 +47,12 @@ final class ClientTest extends TestCase
         new \Drip\Client(["account_id" => "1234", "access_token" => ""]);
     }
 
+    public function testMissingCredentials()
+    {
+        $this->expectException(\Drip\Exception\InvalidArgumentException::class);
+        new \Drip\Client(["account_id" => "1234"]);
+    }
+
     public function testDeprecatedInvalidAccountId()
     {
         $this->expectException(\Drip\Exception\InvalidAccountIdException::class);

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -11,22 +11,52 @@ require_once 'GuzzleHelpers.php';
 
 final class ClientTest extends TestCase
 {
-    public function testInitializedWithApiToken()
+    public function testDeprecatedInitializedWithApiKey()
     {
         $client = new \Drip\Client("abc123", "1234");
         $this->assertInstanceOf(\Drip\Client::class, $client);
     }
 
-    public function testInvalidApiToken()
+    public function testInitializedWithAccessToken()
     {
-        $this->expectException(\Drip\Exception\InvalidApiTokenException::class);
+        $client = new \Drip\Client(array("account_id" => "1234", "access_token" => "abc123"));
+        $this->assertInstanceOf(\Drip\Client::class, $client);
+    }
+
+    public function testInitializedWithApiKey()
+    {
+        $client = new \Drip\Client(array("account_id" => "1234", "api_key" => "abc123"));
+        $this->assertInstanceOf(\Drip\Client::class, $client);
+    }
+
+    public function testDeprecatedInvalidApiKey()
+    {
+        $this->expectException(\Drip\Exception\InvalidApiKeyException::class);
         new \Drip\Client("", "1234");
+    }
+
+    public function testInvalidApiKey()
+    {
+        $this->expectException(\Drip\Exception\InvalidApiKeyException::class);
+        new \Drip\Client(array("account_id" => "1234", "api_key" => ""));
+    }
+
+    public function testInvalidAccessToken()
+    {
+        $this->expectException(\Drip\Exception\InvalidAccessTokenException::class);
+        new \Drip\Client(array("account_id" => "1234", "access_token" => ""));
+    }
+
+    public function testDeprecatedInvalidAccountId()
+    {
+        $this->expectException(\Drip\Exception\InvalidAccountIdException::class);
+        new \Drip\Client("abc123", "");
     }
 
     public function testInvalidAccountId()
     {
         $this->expectException(\Drip\Exception\InvalidAccountIdException::class);
-        new \Drip\Client("abc123", "");
+        new \Drip\Client(array("account_id" => "", "api_key" => "abc123"));
     }
 
     public function testErrorResponseReturned()

--- a/tests/support/GuzzleHelpers.php
+++ b/tests/support/GuzzleHelpers.php
@@ -17,7 +17,9 @@ class GuzzleHelpers
      */
     public static function mocked_client(&$history_object, $responses)
     {
-        return new \Drip\Client("abc123", 12345, [
+        return new \Drip\Client([
+            'account_id' => '12345',
+            'api_key' => 'abc123',
             'api_end_point' => 'http://api.example.com/v9001/',
             'guzzle_stack_constructor' => function () use (&$history_object, $responses) {
                 $mock = new MockHandler($responses);


### PR DESCRIPTION
Closes #25 

Fulfills request to use Bearer authorization. I successfully tested this locally.

Currently, the way the documentation says an access token can be used is not valid. The new API definition is as follows.
```
$client = new \Drip\Client(["account_id" => "YOUR_ACCOUNT_ID", "access_token" => "YOUR_ACCESS_TOKEN"]);
$client = new \Drip\Client(["account_id" => "YOUR_ACCOUNT_ID", "api_key" => "YOUR_API_KEY"]);
```

The intention is to continue to support the previous client definition and maybe remove it eventually.
```
$client = new \Drip\Client("YOUR_API_KEY", "YOUR_ACCOUNT_ID");
```

I also changed references in the code from "api token" to "api key" just for clarity and consistency.



 Very open for suggestions on how this could be cleaned up or made better. 