### PR TITLE
Update guzzle to ^7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: php
 php:
-  - '5.6'
-  - '7.0'
-  - '7.1'
   - '7.2'
+  - '7.3'
+  - '7.4'
 install:
   - 'make install'
 script:

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,6 @@
     "squizlabs/php_codesniffer": "3.*"
   },
   "require": {
-    "guzzlehttp/guzzle": "^6.3"
+    "guzzlehttp/guzzle": "^7.0"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     "squizlabs/php_codesniffer": "3.*"
   },
   "require": {
+    "php": "^7.2",
     "guzzlehttp/guzzle": "^7.0"
   }
 }


### PR DESCRIPTION
Updates Guzzle to 7.0 for compatibility with Laravel 8.

Guzzle upgrade notes from 6.x to 7: https://github.com/guzzle/guzzle/blob/master/UPGRADING.md