### PR TITLE
Adds shopper_activity v3 end points

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 /vendor
 /composer.lock
 /.vscode
+/.idea
 /.phpunit.result.cache

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -510,6 +510,9 @@ final class ClientTest extends TestCase
         $response = $client->untag_subscriber(['email' => 'test@example.com']);
     }
 
+    // Shopper Activity (v3)
+    // Todo add tests for the create_or_update_cart, create_or_update_order, and create_or_update_product methods.
+
     ////////////////////////// E V E N T S //////////////////////////
 
     // #record_event


### PR DESCRIPTION
## Background

The current SDK does not allow for v3 shopper activity endpoint calls necessary for updating shopping cart data, and ordering data. This update adds the ability to do that.

## Modification

- Cleaned up php doc block refs to use imported / simplified class references for @throws \Exception => @throws Exception and @return \Drip\RepsonseInterface => @return ResponseInterface
- Added 3 methods (with v3 endpoint check) for `shopper_activity/cart`, `shopper_activity/order` and `shopper_activity/product`.
- Caller must use the params (Argument 3) in the constructor to set `api_end_point` to `https://api.getdrip.com/v3/` to use the shopper activity endpoint. If `v3` is not found in the current end point url, and error will be thrown. This information should be added to the README.md or general docs page. (not done by me).
- Added TODO comment for tests. I'm not familiar with how the tests should be set up for this so I'm not going to do it myself but the maintainers can feel free to add them.

## Result

Provides the ability to use the v3  `shopper_activity/cart`, `shopper_activity/order` and `shopper_activity/product` end points.

## Additional Context

N/A

## How to verify/test

I did not have time to create new tests for this work as I'm not quite following how your tests are done and I'm not super experienced with TDD so I inserted a TODO comment where the tests should be added. I have tested this manually against the production servers on a product site and the three new endpoints seem to function correctly.

